### PR TITLE
Enable deployment on merged pull requests to release branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@ name: Build and deploy Node.js project to Azure Function App - postech-fiap-serv
 
 on:
   push:
+  pull_request:
+    branches:
+      - 'release/*'
   workflow_dispatch:
 
 env:
@@ -41,7 +44,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/release*'
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.ref, 'refs/heads/release/')
 
     permissions:
       id-token: write #This is required for requesting the JWT


### PR DESCRIPTION
Previously, the workflow only triggered on direct pushes to release branches. Now, it also triggers when pull requests are merged into these branches, ensuring deployments are consistent and automated. This change prevents manual interventions and aligns with best practices for CI/CD workflows.