### PR TITLE
Fix deploy condition for pull request events

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,7 @@
 name: Build and deploy Node.js project to Azure Function App - postech-fiap-serverless
 
 on:
-  push:
   pull_request:
-    branches:
-      - 'release/*'
   workflow_dispatch:
 
 env:
@@ -44,7 +41,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.ref, 'refs/heads/release/')
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.base_ref, 'release/')
 
     permissions:
       id-token: write #This is required for requesting the JWT


### PR DESCRIPTION
Modified the deploy condition in the GitHub Actions workflow to use 'github.base_ref' instead of 'github.ref' for detecting release branches. This ensures the deployment only triggers when a pull request is merged into a release branch.