### PR TITLE
Update deployment trigger for pull request events

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,7 @@ name: Build and deploy Node.js project to Azure Function App - postech-fiap-serv
 
 on:
   pull_request:
+    types: [opened, closed]
   workflow_dispatch:
 
 env:
@@ -41,7 +42,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.base_ref, 'release/')
+    if: github.event.pull_request.merged == true && startsWith(github.base_ref, 'release/')
 
     permissions:
       id-token: write #This is required for requesting the JWT


### PR DESCRIPTION
Modify the deployment workflow to trigger on 'opened' and 'closed' pull request events. Additionally, remove the redundant check for the 'pull_request' event name in the conditional logic.